### PR TITLE
feat: use `XDG_CONFIG_HOME` for config directory when set

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"log"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -11,11 +12,15 @@ var FARGO_VERSION string
 
 // Initialize configuration using Viper
 func Load() string { // Load config and return config file path
+	configDir, err := ConfigDir()
+	if err != nil {
+		log.Fatalf("Error getting config file: %v", err)
+	}
 	viper.SetEnvPrefix("FARGO")
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.SetConfigName("config")
-	viper.AddConfigPath("$HOME/.fargo")
+	viper.AddConfigPath(configDir)
 	viper.SetConfigType("yaml")
 
 	defaults := map[string]interface{}{
@@ -34,7 +39,7 @@ func Load() string { // Load config and return config file path
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			log.Println("Creating ~/.fargo/config.yaml")
+			log.Printf("Creating %s", filepath.Join(configDir, "config.yaml"))
 			viper.SafeWriteConfig()
 		} else {
 			log.Fatalf("Error reading config file: %v", err)
@@ -43,7 +48,9 @@ func Load() string { // Load config and return config file path
 	return viper.ConfigFileUsed()
 }
 
-var GetString = viper.GetString
-var GetInt = viper.GetInt
-var GetBool = viper.GetBool
-var BindPFlag = viper.BindPFlag
+var (
+	GetString = viper.GetString
+	GetInt    = viper.GetInt
+	GetBool   = viper.GetBool
+	BindPFlag = viper.BindPFlag
+)

--- a/config/xdg.go
+++ b/config/xdg.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+const fargoDir = "fargo"
+
+const envXdgConfig = "XDG_CONFIG_HOME"
+
+func dirExists(p string) (bool, error) {
+	info, err := os.Stat(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("%s is not a directory", p)
+	}
+	return true, nil
+}
+
+// ConfigDir returns the path to the configuration directory.
+// Defaults to "~/.fargo", or "$XDG_CONFIG_HOME/fargo" if XDG_CONFIG_HOME is set.
+// If both paths exist, it prioritizes "$XDG_CONFIG_HOME/fargo".
+// This function creates the path if it does not already exist.
+//
+// See: https://specifications.freedesktop.org/basedir-spec/latest/
+func ConfigDir() (string, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current user: %w", err)
+	}
+	defaultPath := filepath.Join(usr.HomeDir, "."+fargoDir)
+	defaultPathExists, err := dirExists(defaultPath)
+	if err != nil {
+		return "", err
+	}
+
+	xdgConfig, ok := os.LookupEnv(envXdgConfig)
+	if ok && xdgConfig != "" {
+		xdgConfigPath := filepath.Join(xdgConfig, fargoDir)
+		xdgConfigPathExists, err := dirExists(xdgConfigPath)
+		if err != nil {
+			return "", err
+		}
+
+		if xdgConfigPathExists || !defaultPathExists {
+			if !xdgConfigPathExists {
+				if err := os.Mkdir(xdgConfigPath, 0755); err != nil {
+					return "", fmt.Errorf("failed to create dir %s: %w", xdgConfigPath, err)
+				}
+			}
+			return xdgConfigPath, nil
+		}
+	}
+
+	if !defaultPathExists {
+		if err := os.Mkdir(defaultPath, 0755); err != nil {
+			return "", fmt.Errorf("failed to create dir %s: %w", defaultPath, err)
+		}
+	}
+
+	return defaultPath, nil
+}

--- a/config/xdg_test.go
+++ b/config/xdg_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigDir(t *testing.T) {
+	homeDir := func() string {
+		t.Helper()
+		usr, err := user.Current()
+		if err != nil {
+			t.Fatalf("failed to get current user: %v", err)
+		}
+
+		return usr.HomeDir
+	}
+
+	t.Run("XDG_CONFIG_HOME is set", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv(envXdgConfig, tmpDir)
+
+		configDir, err := ConfigDir()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expected := filepath.Join(tmpDir, "fargo")
+		if configDir != expected {
+			if configDir == filepath.Join(homeDir(), ".fargo") {
+				t.Fatal("you should run this test without ~/.fargo dir")
+			}
+			t.Fatalf("expected %v, got %v", expected, configDir)
+		}
+		if _, err := os.Stat(configDir); err != nil {
+			t.Fatalf("failed to check config dir: %v", err)
+		}
+	})
+
+	t.Run("XDG_CONFIG_HOME is not set", func(t *testing.T) {
+		t.Setenv(envXdgConfig, "")
+
+		configDir, err := ConfigDir()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expected := filepath.Join(homeDir(), ".fargo")
+		if configDir != expected {
+			t.Fatalf("expected %v, got %v", expected, configDir)
+		}
+		if _, err := os.Stat(configDir); err != nil {
+			t.Fatalf("failed to check config dir: %v", err)
+		}
+	})
+}

--- a/localdb/localdb.go
+++ b/localdb/localdb.go
@@ -6,13 +6,12 @@ import (
 	"errors"
 	"io"
 	"os"
-	"os/user"
 	"path/filepath"
+
+	"github.com/vrypan/fargo/config"
 )
 
 var db_path = ""
-
-const dot_dir = ".fargo"
 
 type db_value struct {
 	Idx uint64
@@ -28,23 +27,10 @@ type _kv_store struct {
 
 var kv_store = _kv_store{Kv: make(map[string]db_value)}
 
-var ERR_NOT_FOUND = errors.New("Not Found")
-var ERR_NOT_STORED = errors.New("Not Stored")
-
-func createDotDir() (string, error) {
-	usr, err := user.Current()
-	if err != nil {
-		return "", err
-	}
-	dotDir := filepath.Join(usr.HomeDir, dot_dir)
-	if _, err := os.Stat(dotDir); os.IsNotExist(err) {
-		err = os.Mkdir(dotDir, 0755)
-		if err != nil {
-			return "", err
-		}
-	}
-	return dotDir, nil
-}
+var (
+	ERR_NOT_FOUND  = errors.New("Not Found")
+	ERR_NOT_STORED = errors.New("Not Stored")
+)
 
 func Set(k string, v string) error {
 	if db_v, exists := kv_store.Kv[k]; exists {
@@ -80,11 +66,11 @@ func save() error {
 
 func load() error {
 	if db_path == "" {
-		if dotDir, err := createDotDir(); err != nil {
+		configDir, err := config.ConfigDir()
+		if err != nil {
 			return err
-		} else {
-			db_path = filepath.Join(dotDir, "local.db")
 		}
+		db_path = filepath.Join(configDir, "local.db")
 	}
 
 	b, err := os.ReadFile(db_path)


### PR DESCRIPTION
This PR introduces the `ConfigDir` function to get the config directory path, respecting the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/#index).

If the `$XDG_CONFIG_HOME` environment variable is set, the function will use the `$XDG_CONFIG_HOME/fargo` path for the config file.

I made this PR to keep the `$HOME` directory clean while using `fargo`.

Also, the function will now create the configuration directory if it doesn't exist, fixing a problem where running `fargo get` without the `.fargo` directory would cause the message `Creating .../.fargo/config.yaml` to appear multiple times.