### PR TITLE
Fix snapshot panic and expand download path

### DIFF
--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -70,6 +70,9 @@ func getSnapshot(cmd *cobra.Command, args []string) {
 
 	log.Println("Fetching casts...")
 	casts := fctools.NewCastGroup().FromCastFidHash(hub, user.Fid, parts[0][2:], expandFlag)
+	if casts == nil || len(casts.Messages) == 0 {
+		log.Fatalf("Failed to get cast or thread %s", parts[0])
+	}
 
 	s := tui.PprintThread(casts, nil, 0, "", "")
 	err = os.WriteFile(filepath.Join(path, "thread.txt"), []byte(s), 0644)

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -23,11 +24,16 @@ func Load() string { // Load config and return config file path
 	viper.AddConfigPath(configDir)
 	viper.SetConfigType("yaml")
 
+	defaultDownload := "~/Downloads"
+	if home, err := os.UserHomeDir(); err == nil {
+		defaultDownload = filepath.Join(home, "Downloads")
+	}
+
 	defaults := map[string]interface{}{
 		"hub.host":     "hoyt.farcaster.xyz",
 		"hub.port":     "2283",
 		"hub.ssl":      "true",
-		"download.dir": "~/Downloads",
+		"download.dir": defaultDownload,
 		"get.count":    20,
 		"cast.fid":     0,
 		"cast.privkey": "",


### PR DESCRIPTION
Expands `~` to home dir when creating default config and prevents a panic when attempting to create a tui thread string when we failed to get the castgroup.

Prevents the following errors
```
Failed to create output directory /home/csweeney/projects/fargo/~/Downloads/snapshot-0x3e9f6825dc23a14efb4c5d71723f5bea2f89095f: mkdir /home/csweeney/projects/fargo/~/Downloads/snapshot-0x3e9f6825dc23a14efb4c5d71723f5bea2f89095f: no such file or directory
```

(nil cast group due to bad URI)
```
➜ go run . snapshot @martin/0x364e192b
Snapshot path: /home/csweeney/Downloads/snapshot-0x364e192b
Fetching casts...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xeb4c9c]

goroutine 1 [running]:
github.com/vrypan/fargo/tui.PprintThread(0xc000787ae8?, 0x114dc64?, 0x0, {0x0, 0x0}, {0x0, 0x0})
        /home/csweeney/projects/fargo/tui/tui.go:320 +0x7c
github.com/vrypan/fargo/cmd.getSnapshot(0x1bcb360, {0xc000537bb0, 0x1, 0x1})
        /home/csweeney/projects/fargo/cmd/snapshot.go:79 +0x859
github.com/spf13/cobra.(*Command).execute(0x1bcb360, {0xc000537b70, 0x1, 0x1})
        /home/csweeney/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0x1bcaac0)
        /home/csweeney/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/csweeney/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/vrypan/fargo/cmd.Execute()
        /home/csweeney/projects/fargo/cmd/root.go:17 +0x27
main.main()
        /home/csweeney/projects/fargo/main.go:9 +0xf
exit status 2

```

